### PR TITLE
Fix version and effective date on page 2 (#143)

### DIFF
--- a/docs/EVG.md
+++ b/docs/EVG.md
@@ -26,7 +26,7 @@ This document is a translation of the original English version. In the event tha
 
 Guidelines for the Issuance and Management of Extended Validation Certificates
 
-This version 1.6.9 represents the Extended Validation Guidelines, as adopted by the CA/Browser Forum as of Ballot SC16, passed by the Forum on 15 March 2019 and effective as of 16 April 2019.
+This version 1.7.0 represents the Extended Validation Guidelines, as adopted by the CA/Browser Forum as of Ballot SC17, passed by the Forum on 21 May 2019 and effective as of 21 June 2019.
 
 The Guidelines describe an integrated set of technologies, protocols, identity proofing, lifecycle management, and auditing practices specifying the minimum requirements that must be met in order to issue and maintain Extended Validation Certificates ("EV Certificates") concerning an organization.  Subject Organization information from valid EV Certificates can then be used in a special manner by certain relying-party software applications (e.g., browser software) in order to provide users with a trustworthy confirmation of the identity of the entity that controls the Web site or other services they are accessing.  Although initially intended for use in establishing Web-based data communication conduits via TLS/SSL protocols, extensions are envisioned for S/MIME, time-stamping, VoIP, IM, Web services, etc.
 


### PR DESCRIPTION
Although the information already exists in the "Document History" table, we forgot to update the version and effective date on page 2.